### PR TITLE
Add name to ack. for ML-BOM guide

### DIFF
--- a/ML-BOM/en/0x04-Acknowledgements.md
+++ b/ML-BOM/en/0x04-Acknowledgements.md
@@ -17,6 +17,7 @@ We would like to specifically acknowledge the following individuals for their mu
 - Saquib Saifee, IBM
 - Colin Gigool, IBM
 - Aliza Heching, IBM
+- Nagalakshmi Satyanarayanan, IBM
 - Pavel Shukhman, Reliza
 
 


### PR DESCRIPTION
Missed a name for the Acknowledgements page.