### PR TITLE
docs(ML-BOM): remove model field not present in schema

### DIFF
--- a/ML-BOM/en/0x40-Design-Additional-Model-Information.md
+++ b/ML-BOM/en/0x40-Design-Additional-Model-Information.md
@@ -288,7 +288,6 @@ First, create entries for all the "components" used in the training process as p
       {
         "type": "device",
         "name": "NVIDIA H100 Tensor Core GPU",
-        "model": "H100 PCIe",
         "description": "NVIDIA H100 Tensor Core GPU PCIe Device",
         "bom-ref": "nvidia-h100-pcie-gpu-1"
       },


### PR DESCRIPTION
Removes the "model" field from the AIBOM component example, as it's not present in the CycloneDX 1.7 schema.