### PR TITLE
Fix typos and misspellings in ML-BOM guide

### DIFF
--- a/ML-BOM/en/0x20-Design-Model-Component-Metadata.md
+++ b/ML-BOM/en/0x20-Design-Model-Component-Metadata.md
@@ -282,7 +282,7 @@ CycloneDX allows for declarations of software compositions (e.g., hardware produ
 
 In the case of a model repository like those hosted in Hugging Face, one can describe the files that comprise it as a composition with an ML-BOM.  Specifically, it would be declared as a composition of an assembly type.
 
-Specifically, a `component` entry would be created for each file and declared in the ML-BOM's `components` array hierarchically under the model's `component` then declare the assembly relationship within within the BOM's `compositions` array under `assemblies` by providing the `bom-ref` link to the model component that contains the hierarchy of the constituting (file) components within the model repository.
+Specifically, a `component` entry would be created for each file and declared in the ML-BOM's `components` array hierarchically under the model's `component` then declare the assembly relationship within the BOM's `compositions` array under `assemblies` by providing the `bom-ref` link to the model component that contains the hierarchy of the constituting (file) components within the model repository.
 
 <div style="page-break-after: always; visibility: hidden">
 \newpage
@@ -416,7 +416,7 @@ It is important to capture any of these transformations in the model's lineage (
       "purl": "pkg:huggingface/unsloth/Llama-3.2-3B-Instruct@1.0.0",
       "bom-ref": "pkg:huggingface/unsloth/Llama-3.2-3B-Instruct@1.0.0",
       "publisher": "Unsloth",
-      "description": "A pre-optimized, specialized versions of the meta-llama/Llama-3.2-3B-Instruct model designed to work seamlessly with Unsloth's training framework",
+      "description": "A pre-optimized, specialized version of the meta-llama/Llama-3.2-3B-Instruct model designed to work seamlessly with Unsloth's training framework",
       // ...,
       "pedigree": {
         "ancestors": [

--- a/ML-BOM/en/0x22-Design-Model-Card-Parameters.md
+++ b/ML-BOM/en/0x22-Design-Model-Card-Parameters.md
@@ -2,7 +2,7 @@
 
 ![](images/ml-anatomy-model-card-parameters.svg)
 
-This section will feature guidance on filling out information in the Cyclone model card's `modelParameters` object and its subcomponents, including:
+This section will feature guidance on filling out information in the CycloneDX model card's `modelParameters` object and its subcomponents, including:
 
 * [Model metadata](#model-metadata)
   * [Approach](#approach) - The overall approach to learning used by the model for problem solving.
@@ -56,7 +56,7 @@ The model architecture family field should include descriptive names of neural n
 Some examples of commonly referenced neural network (NN) architecture families include:
 
 * **Transformers** - an architecture designed to process sequential data (like text, speech, or images) in parallel rather than in order.
-* **Convolutional Neural Network (CNN)** - an architecture designed to process efficiently detect patterns (like edges, shapes, and textures) to typically classify or analyze visual (videos/image) or auditory data, but can applied to text analysis, behavioral patterns and more.
+* **Convolutional Neural Network (CNN)** - an architecture designed to efficiently detect patterns (like edges, shapes, and textures) to typically classify or analyze visual (videos/image) or auditory data, but can be applied to text analysis, behavioral patterns and more.
 * **Recurrent Neural Network (RNN)** - an architecture designed for processing sequential data like text, speech, and time series, typically used for tasks where order matters, such as language translation, speech recognition and time-series forecasting.
 * **Long Short-Term Memory (LSTM)** -  a specialized variant of a Recurrent Neural Network (RNN) architecture designed specifically to overcome the limitations of traditional RNNs in learning long-term dependencies.
 * **Gated Recurrent Units (GRUs)** a specialized variant of a Recurrent Neural Network (RNN) architecture designed to overcome challenges like the vanishing gradient problem and enhance the modeling of long-term dependencies in sequential datasets.
@@ -70,7 +70,7 @@ The model architecture field is intended to include specific keywords to identif
 
 These are typically found in one of several locations relative to the model:
 
-* **Model Card**: the associated "model card" (e.g., `README.md` in Hugging Face) may contain a mentions of specific class names like `LlamaForCausalLM`, `BertModel`, or `VisionTransformer`.
+* **Model Card**: the associated "model card" (e.g., `README.md` in Hugging Face) may contain mentions of specific class names like `LlamaForCausalLM`, `BertModel`, or `VisionTransformer`.
 * **Framework-Specific Implementation Keywords** or tags: Depending on your code environment (PyTorch, TensorFlow, llama.cpp, etc.) that identify specific model code within the platform or environment.
 * **Framework-Specific Configuration files** (e.g., Hugging Face transformer's `config.json` file): may contain the name of the class or function used to configure the framework for the specific implementation recommended for the associated model.
 * **Academic Research Papers** (e.g., arXiv): may include detailed descriptors of processing algorithms, supported training or inference engines or specific, named implementations

--- a/ML-BOM/en/0x23-Design-Model-Card-Quantitative-Analysis.md
+++ b/ML-BOM/en/0x23-Design-Model-Card-Quantitative-Analysis.md
@@ -2,7 +2,7 @@
 
 ![](images/ml-anatomy-model-card-quant-analysis.svg)
 
-This section will feature guidance on filling out information in the Cyclone model card's `quantitativeAnalysis` object and its subcomponents, including:
+This section will feature guidance on filling out information in the CycloneDX model card's `quantitativeAnalysis` object and its subcomponents, including:
 
 * [Metrics](#metrics)
   * [Performance metrics](#performance-metrics)

--- a/ML-BOM/en/0x24-Design-Model-Card-Considerations.md
+++ b/ML-BOM/en/0x24-Design-Model-Card-Considerations.md
@@ -2,7 +2,7 @@
 
 ![](images/ml-anatomy-model-card-considerations.svg)
 
-This section will feature guidance on filling out information in the Cyclone model card's design `considerations` object and its subcomponents, including:
+This section will feature guidance on filling out information in the CycloneDX model card's design `considerations` object and its subcomponents, including:
 
 * [Users](#users) - Who are the intended users of the model?
 * [Use cases](#use-cases)-  What are the intended use cases for the model inclusive of the Operational Design Domains (ODD)?
@@ -109,7 +109,7 @@ Some of these tradeoff considerations include:
 
 ###### Example: Performance tradeoffs for Qwen-7B
 
-This example shows how to provide performance trade-offs for a few acknowledged parameters in the Qwen3 &B parameter model.
+This example shows how to provide performance trade-offs for a few acknowledged parameters in the Qwen3 7B parameter model.
 
 ```json
 "component": {
@@ -169,7 +169,7 @@ Based on technical reports and safety evaluations such as Qwen3Guard, the follow
           "mitigationStrategy": "Explicitly instruct the model to \"Prioritize Safety\" in the prompt and use Retrieval-Augmented Generation (RAG) to ground responses in verified external documents."
         },
         {
-          "name": "Privacy, Sensitive or Personally Identifiable Information (PII)Content Leakage. If such data was present in the pre-training corpus, this risk for generation od such data is possible.",
+          "name": "Privacy, Sensitive or Personally Identifiable Information (PII) Content Leakage. If such data was present in the pre-training corpus, this risk for generation of such data is possible.",
           "mitigationStrategy": "Deploy the model locally using tools like Ollama to ensure sensitive data stays within a secure environment, and apply regex-based PII scrubbing to outputs."
         },
         {

--- a/ML-BOM/en/0x40-Design-Additional-Model-Information.md
+++ b/ML-BOM/en/0x40-Design-Additional-Model-Information.md
@@ -90,7 +90,7 @@ Models can be trained in one or more languages (i.e., multilingual models).
 
 ###### Field discussion
 
-* **properties** - The `value` reflects the set (list) of ISO 639-1 language codes the model was trained to on and thus capable of understanding as input and generating as output.
+* **properties** - The `value` reflects the set (list) of ISO 639-1 language codes the model was trained on and thus capable of understanding as input and generating as output.
 
 
 ### Providing free-form tags for search

--- a/ML-BOM/en/0x90-Appendix-A_Glossary.md
+++ b/ML-BOM/en/0x90-Appendix-A_Glossary.md
@@ -34,7 +34,7 @@ A neural network consists of connected units or nodes called artificial neurons,
 
 ##### Prompt engineering
 
-The process of structuring or crafting an instruction in order to produce better outputs from a generative artificial intelligence (AI) model. It typically involves designing clear queries, adding relevant context, and refining wording to guide the model toward more accurate, useful, and consistent responses/ [1]
+The process of structuring or crafting an instruction in order to produce better outputs from a generative artificial intelligence (AI) model. It typically involves designing clear queries, adding relevant context, and refining wording to guide the model toward more accurate, useful, and consistent responses. [1]
 
 [1] [Wikipedia - prompt engineering](https://en.wikipedia.org/wiki/Prompt_engineering)
 
@@ -62,7 +62,7 @@ The transformer's neural network architecture takes input data, converts it to n
 
 ##### Natural Language Processing (NLP)
 
-is the processing of natural language information by a computer. NLP is a subfield of computer science and is closely associated with artificial intelligence. NLP is also related to information retrieval, knowledge representation, computational linguistics, and linguistics more broadly.
+Natural Language Processing (NLP) is the processing of natural language information by a computer. NLP is a subfield of computer science and is closely associated with artificial intelligence. NLP is also related to information retrieval, knowledge representation, computational linguistics, and linguistics more broadly.
 
 Major processing tasks in an NLP system include: speech recognition, text classification, natural language understanding (NLU), and natural language generation. [1]
 
@@ -79,7 +79,7 @@ Safetensors addresses security and efficiency limitations present in traditional
 A safetensors file contains:
 
 * A metadata section saved in JSON format. This section provides information on all tensors in the model, including their shapes, data types, and names. It can optionally also contain custom metadata.
-* A section for the tensor data.* A section for the tensor data.
+* A section for the tensor data.
 
 [1] https://huggingface.co/blog/ngxson/common-ai-model-formats
 

--- a/ML-BOM/en/0x91-Appendix-B_References.md
+++ b/ML-BOM/en/0x91-Appendix-B_References.md
@@ -81,7 +81,7 @@ Hugging Face model (repositories) typically support the `.safetensors` Hugging F
 
 ONNX models are typically single file format ending with the `.onnx` extension.
 
-> **Note**: Most ONNX models have transitioned to and are now registered in Huggingface, but are downloaded from linked GitHub repository files not within the HF repo. itself.
+> **Note**: Most ONNX models have transitioned to and are now registered in Huggingface, but are downloaded from linked GitHub repository files not within the HF repo itself.
 
 * Hugging Face
   * [onnx/DenseNet-121-9](https://huggingface.co/onnx/DenseNet-121-9/tree/main) - `densenet-9.onnx`

--- a/ML-BOM/en/0x93_Appendix-C_Complete_Example.md
+++ b/ML-BOM/en/0x93_Appendix-C_Complete_Example.md
@@ -1,4 +1,4 @@
-# Appendix C: References
+# Appendix C: Complete Example
 
 This appendix includes a complete AI/ML BOM example that combines most of the isolated examples for the Qwen model shown throughout this guide.
 


### PR DESCRIPTION
## Summary
- Corrects a handful of small typos and misspellings scattered across the ML-BOM guide chapters and appendices (duplicated/missing words, "Cyclone" → "CycloneDX", a mislabeled appendix title, etc.)
- No content, structure, or example data was changed — text only

## Test plan
- Read through each changed line in context to confirm the fix reads correctly