### PR TITLE
Fix malformed JSON in ML-BOM guide examples

### DIFF
--- a/ML-BOM/en/0x20-Design-Model-Component-Metadata.md
+++ b/ML-BOM/en/0x20-Design-Model-Component-Metadata.md
@@ -265,7 +265,6 @@ It is important to disclose information regarding a model's release.  This is ac
             // ...
           ]
         }
-      ]
     },
     // ...
   }
@@ -374,11 +373,11 @@ Then the model component's new hierarchy of composing files would be described a
 {
   "$schema": "http://cyclonedx.org/schema/bom-1.7.schema.json",
   // ...,
-  "composition": [
+  "compositions": [
     {
       "aggregate": "complete",
       "assemblies": [
-        "pkg:huggingface/Qwen/Qwen-7B@ef3c5c9",
+        "pkg:huggingface/Qwen/Qwen-7B@ef3c5c9"
       ]
     }
   ],

--- a/ML-BOM/en/0x22-Design-Model-Card-Parameters.md
+++ b/ML-BOM/en/0x22-Design-Model-Card-Parameters.md
@@ -97,8 +97,9 @@ This example demonstrates best practices for the Qwen-7B model using information
           "modelArchitecture": "QWenLMHeadModel",
           "approach": {
             "type": "supervised"
-          },
+          }
         // ...
+        }
       }
     }
   }

--- a/ML-BOM/en/0x24-Design-Model-Card-Considerations.md
+++ b/ML-BOM/en/0x24-Design-Model-Card-Considerations.md
@@ -46,7 +46,7 @@ This example shows a list of what kind of user and use case information would be
         "Implementing the model on specialized hardware for real-time visual perception and \"Thinking Mode\" reasoning to help an intelligent device navigate and interact with its environment based on natural language commands",
         "Running a self-hosted instance to analyze internal security logs for anomalies, ensuring that sensitive infrastructure data never leaves the organization's firewall.",
         "Running a personal assistant locally on a laptop to answer questions or process private information such as emails or calendars without sending data to an external server."
-      ],
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary
- Removes a stray closing bracket in the release-notes example and adds a missing closing brace to the model-card example so both are structurally balanced
- Removes two invalid trailing commas (assemblies and use-cases examples)
- Corrects the assembly-composition example to use `compositions` (plural), matching the field name used everywhere else in the guide including the complete example in Appendix C
- No other content changed

## Test plan
- Verified brace/bracket balance across every JSON code block in the three changed files