### PR TITLE
Fix style inconsistencies in ML-BOM guide

### DIFF
--- a/ML-BOM/en/0x24-Design-Model-Card-Considerations.md
+++ b/ML-BOM/en/0x24-Design-Model-Card-Considerations.md
@@ -95,7 +95,7 @@ This example shows a list of technical limitations that might be associated with
 ```
 
 
-## Performance Tradeoffs
+## Performance tradeoffs
 
 When creating Machine Learning (ML) models, developers must navigate several core performance tradeoffs to align model capabilities with business needs and technical constraints.
 
@@ -109,7 +109,7 @@ Some of these tradeoff considerations include:
 
 ###### Example: Performance tradeoffs for Qwen-7B
 
-This example shows how to provide performance trade-offs for a few acknowledged parameters in the Qwen3 &B parameter model.
+This example shows how to provide performance tradeoffs for a few acknowledged parameters in the Qwen3 7B parameter model.
 
 ```json
 "component": {
@@ -240,7 +240,7 @@ This example shows how fairness assessment information would be included in a Cy
 
 This section describes how model providers can publish the energy costs incurred at different stages of the model's lifecycle to address potential regulatory requirements.  This information includes the energy sources (i.e., for the datacenters) as well as disclosure of CO2 emission cost equivalents and CO2 offsets (credits).
 
-The intent is for CycloneDX to be able to support the general requirements referenced by the [EU’s AI Act](https://eur-lex.europa.eu/eli/reg/2024/1689/oj/eng), which refers to ‘environmental protection’ in its subject matter.
+The intent is for CycloneDX to be able to support the general requirements referenced by the [EU's AI Act](https://eur-lex.europa.eu/eli/reg/2024/1689/oj/eng), which refers to 'environmental protection' in its subject matter.
 
 Summary of EU AI Act Environmental Disclosure Rules for GPAI Models:
 

--- a/ML-BOM/en/0x40-Design-Additional-Model-Information.md
+++ b/ML-BOM/en/0x40-Design-Additional-Model-Information.md
@@ -11,7 +11,6 @@ For convenience, here are links to the specific sections for some of these ackno
   * [Annotating a model's supported languages](#annotating-a-models-supported-languages)
   * [Providing a model's usage policy](#providing-a-models-usage-policy)
   * [Providing free-form tags for search](#providing-free-form-tags-for-search)
-  * [Providing a model's usage policy](#providing-a-models-usage-policy)
 * [Tokenizers and prompt templates](#tokenizers-and-prompt-templates)
 * [Including manufacturing information for the ML model](#including-manufacturing-information-for-the-ml-model)
   * [Declaring hardware and software training components](#declaring-hardware-and-software-training-components)
@@ -117,7 +116,7 @@ This section describes how to "tag" model components with non-standard keywords 
 
 ###### Field discussion
 
-* **properties** - The tag values shown above might be used to search for models in a catalog that are compatible with the `pytorch` framework and (the Hugging Face) `transformers` library.  The `text-to-speech` and `speech-to-speech` tags could identify the model with those input/output capabilities.
+* **tags** - The tag values shown above might be used to search for models in a catalog that are compatible with the `pytorch` framework and (the Hugging Face) `transformers` library.  The `text-to-speech` and `speech-to-speech` tags could identify the model with those input/output capabilities.
 
 
 ### Providing a model's usage policy
@@ -218,6 +217,8 @@ For the [Qwen/Qwen-7B](https://huggingface.co/Qwen/Qwen-7B) model, the chat temp
   // ...
 }
 ```
+
+###### Field discussion
 
 * **properties** - Utilizes the reserved CycloneDX property name `cdx:ai-ml:model:template:chat`, with the name widely used `ChatML` template.
 


### PR DESCRIPTION
## Summary
- Removes a duplicated table-of-contents entry
- Fixes a field-discussion bullet mislabeled `**properties**` where it should read `**tags**`
- Adds a missing "Field discussion" section header before a bullet that was floating without one
- Normalizes a couple of curly quotes to the straight quotes used throughout the rest of the guide
- Aligns "Performance Tradeoffs" heading casing with sibling sentence-case headings, and "trade-offs" wording with the "tradeoffs" spelling used everywhere else (including the `performanceTradeoffs` field name)
- No content, structure, or example data was changed

## Test plan
- Read through each changed section in context to confirm it reads correctly and matches surrounding style