### PR TITLE
Specify markdown flavor in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ and experiences of the community. Whether through writing, reviewing, or providi
 contributors play a vital role in maintaining the relevance and accuracy of the content, ultimately
 supporting the continuous improvement and adoption of BOM standards globally.
 
-All content in the CycloneDX Authoritative Guides is written in Markdown.
+All content in the CycloneDX Authoritative Guides is written in GitHub Flavored Markdown (GFM).
 
 All images in the CycloneDX Authoritative Guides are in SVG format, ensuring high-quality, 
 resolution-independent visuals.


### PR DESCRIPTION
## Summary
- README.md says content is "written in Markdown" without naming a flavor; the build pipeline is already specific about this (`pandoc -f gfm` in build/build-pdf.sh, and templates/pdf/README.md documents "GFM"), so this brings the top-level README in line with that