### PR TITLE
Fix dataset component names in ML-BOM guide examples

### DIFF
--- a/ML-BOM/en/0x22-Design-Model-Card-Parameters.md
+++ b/ML-BOM/en/0x22-Design-Model-Card-Parameters.md
@@ -268,14 +268,14 @@ The public datasets, as documented in the model's research paper, include:
   },
   "components": [
     {
-      "name": "UltraFeed-back dataset",
+      "name": "UltraFeedback dataset",
       "type": "data",
       "bom-ref": "pkg:huggingface/openbmb/UltraFeedback@40b4365",
       "purl": "pkg:huggingface/openbmb/UltraFeedback@40b436560ca83a8dba36114c22ab3c66e43f6d5e",
       // ...
     },
     {
-      "name": "UltraFeed-back dataset",
+      "name": "Snorkel-Mistral-PairRM-DPO dataset",
       "type": "data",
       "bom-ref": "pkg:huggingface/snorkelai/Snorkel-Mistral-PairRM-DPO@07af5d0a",
       "purl": "pkg:huggingface/snorkelai/Snorkel-Mistral-PairRM-DPO@07af5d0a875b4c692dfaff6c675b10af07b45511",

--- a/ML-BOM/en/0x93_Appendix-C_Complete_Example.md
+++ b/ML-BOM/en/0x93_Appendix-C_Complete_Example.md
@@ -381,13 +381,13 @@ This appendix includes a complete AI/ML BOM example that combines most of the is
       "version": "7c41481f57cb95916b40956ab2f0b139b296d974"
     },
     {
-      "name": "UltraFeed-back dataset",
+      "name": "UltraFeedback dataset",
       "type": "data",
       "bom-ref": "pkg:huggingface/openbmb/UltraFeedback@40b4365",
       "purl": "pkg:huggingface/openbmb/UltraFeedback@40b436560ca83a8dba36114c22ab3c66e43f6d5e"
     },
     {
-      "name": "UltraFeed-back dataset",
+      "name": "Snorkel-Mistral-PairRM-DPO dataset",
       "type": "data",
       "bom-ref": "pkg:huggingface/snorkelai/Snorkel-Mistral-PairRM-DPO@07af5d0a",
       "purl": "pkg:huggingface/snorkelai/Snorkel-Mistral-PairRM-DPO@07af5d0a875b4c692dfaff6c675b10af07b45511"


### PR DESCRIPTION
## Summary
- Both dataset components in the private-dataset example (Appendix C's complete example and the earlier "datasets as data component references" example) were named "UltraFeed-back dataset", even though the second component's `bom-ref`/`purl` point to `snorkelai/Snorkel-Mistral-PairRM-DPO`
- Renames each to match what it actually is, and drops the stray mid-word hyphen in "UltraFeedback"
- No other content changed