### PR TITLE
Fix MMLU confidence interval bounds in ML-BOM guide

### DIFF
--- a/ML-BOM/en/0x23-Design-Model-Card-Quantitative-Analysis.md
+++ b/ML-BOM/en/0x23-Design-Model-Card-Quantitative-Analysis.md
@@ -104,8 +104,8 @@ The MMLU score from the table would be declared as a performance metric as follo
             "type": "MMLU (5-shot)",
             "value": "58.2",
             "confidenceInterval": {
-              "lowerBound": "94.28",
-              "upperBound": "95.72"
+              "lowerBound": "57.48",
+              "upperBound": "58.92"
             }
           }
         ]

--- a/ML-BOM/en/0x93_Appendix-C_Complete_Example.md
+++ b/ML-BOM/en/0x93_Appendix-C_Complete_Example.md
@@ -197,8 +197,8 @@ This appendix includes a complete AI/ML BOM example that combines most of the is
               "type": "MMLU (5-shot)",
               "value": "58.2",
               "confidenceInterval": {
-                "lowerBound": "94.28",
-                "upperBound": "95.72"
+                "lowerBound": "57.48",
+                "upperBound": "58.92"
               }
             },
             {


### PR DESCRIPTION
## Summary
- The MMLU performance-metric example declares `"value": "58.2"` with a `confidenceInterval` of 94.28-95.72, which doesn't bracket the value at all
- The field discussion for this example describes it as "95% ±0.72" - i.e. the stated value ±0.72 at a 95% confidence level, which works out to 57.48-58.92
- Corrects both occurrences (the standalone example and Appendix C's complete example) to 57.48/58.92 so the bounds and the field discussion agree