### PR TITLE
Fix nccl version mismatch in ML-BOM guide examples

### DIFF
--- a/ML-BOM/en/0x40-Design-Additional-Model-Information.md
+++ b/ML-BOM/en/0x40-Design-Additional-Model-Information.md
@@ -281,7 +281,7 @@ First, create entries for all the "components" used in the training process as p
       {
         "type": "library",
         "name": "nccl",
-        "version": "2.19.3",
+        "version": "2.29.2",
         "bom-ref": "pkg:generic/nccl@2.29.2",
         "purl": "pkg:generic/nccl@2.29.2"
       },

--- a/ML-BOM/en/0x93_Appendix-C_Complete_Example.md
+++ b/ML-BOM/en/0x93_Appendix-C_Complete_Example.md
@@ -435,7 +435,7 @@ This appendix includes a complete AI/ML BOM example that combines most of the is
         {
           "type": "library",
           "name": "nccl",
-          "version": "2.19.3",
+          "version": "2.29.2",
           "bom-ref": "pkg:generic/nccl@2.29.2",
           "purl": "pkg:generic/nccl@2.29.2"
         },


### PR DESCRIPTION
## Summary
- The nccl training-component example declares `"version": "2.19.3"` while its own `bom-ref` and `purl` say `pkg:generic/nccl@2.29.2`
- The same example's `runtimeTopology.provides` array separately references `pkg:generic/nccl@2.29.2` too, so 2.29.2 is the value used consistently everywhere else
- Aligns the `version` field with `2.29.2` in both the standalone example and Appendix C's complete example