### PR TITLE
Fix runtimeTopology dependsOn type in ML-BOM guide

### DIFF
--- a/ML-BOM/en/0x40-Design-Additional-Model-Information.md
+++ b/ML-BOM/en/0x40-Design-Additional-Model-Information.md
@@ -345,7 +345,7 @@ Lastly, you would describe the component "stack" as a graph of `runtimeTopology`
        "runtimeTopology": [
        {
           "ref": "pkg:oci/nvidia-pytorch@sha256:f398a0",
-          "dependsOn": "nvidia-h100-pcie-gpu-1",
+          "dependsOn": [ "nvidia-h100-pcie-gpu-1" ],
           "provides": [
             "cuda-toolkit",
             "pkg:oci/nvidia-pytorch@sha256:f398a0",


### PR DESCRIPTION
## Summary
- The runtime-topology example declares `"dependsOn": "nvidia-h100-pcie-gpu-1"` as a bare string
- Per the CycloneDX 1.7 schema, `runtimeTopology[].dependsOn` is `type: array` (a list of bom-ref strings), same as the sibling `provides` field right next to it - a bare string fails schema validation
- Appendix C's complete example (which combines the isolated examples from throughout the guide) already has this correct as `"dependsOn": [ "nvidia-h100-pcie-gpu-1" ]`; this aligns the standalone example with it