### PR TITLE
Fix stray closing brace in Appendix C complete example

### DIFF
--- a/ML-BOM/en/0x93_Appendix-C_Complete_Example.md
+++ b/ML-BOM/en/0x93_Appendix-C_Complete_Example.md
@@ -52,8 +52,7 @@ This appendix includes a complete AI/ML BOM example that combines most of the is
             },
             // ...
           ]
-        }
-      },
+        },
       "externalReferences": [
         {
           "type": "vcs",


### PR DESCRIPTION
## Summary
- Appendix C's complete example carries its own independent copy of the release-notes JSON that a separate PR already fixed elsewhere in the guide (this file wasn't part of that change, since it has its own copy of the content)
- The `releaseNotes` block had an extra `}` closing the model `component` object three fields too early - before `externalReferences`, `properties`, `tags`, `pedigree`, `components`, and `modelCard` are declared
- Because JSON nesting is cumulative, that one stray brace threw off the depth count for the rest of the ~460-line example, ultimately closing the root object early as well
- Fixed by removing the stray brace and moving the trailing comma onto the `releaseNotes` closing brace; verified the full JSON block's brackets now balance end to end