### PR TITLE
fix: correct duplicate appendix lettering in ML-BOM guide

### DIFF
--- a/ML-BOM/en/0x92-Appendix-C_EU-AI-Act-mappings.md
+++ b/ML-BOM/en/0x92-Appendix-C_EU-AI-Act-mappings.md
@@ -1,4 +1,4 @@
-# Appendix A: ML-BOM mappings to the European Union's Artificial Intelligence Act (EU AI Act)
+# Appendix C: ML-BOM mappings to the European Union's Artificial Intelligence Act (EU AI Act)
 
 This appendix maps the [EU's AI Act](https://artificialintelligenceact.eu/) prose requirements and the more prescriptive [Explanatory Notice and Template for the Public Summary of Training Content for general-purpose AI models](https://digital-strategy.ec.europa.eu/en/library/explanatory-notice-and-template-public-summary-training-content-general-purpose-ai-models) to CycloneDX ML-BOM as documented in specific sections of this guide.
 

--- a/ML-BOM/en/0x93_Appendix-D_Complete_Example.md
+++ b/ML-BOM/en/0x93_Appendix-D_Complete_Example.md
@@ -1,4 +1,4 @@
-# Appendix C: References
+# Appendix D: Complete Example
 
 This appendix includes a complete AI/ML BOM example that combines most of the isolated examples for the Qwen model shown throughout this guide.
 


### PR DESCRIPTION
## Summary
- Appendix A (Glossary, `0x90`) and the EU AI Act mappings appendix (`0x92`) both used the heading "Appendix A", and the complete-example appendix (`0x93`) was titled "Appendix C: References" even though Appendix B is already References.
- Renumbers the second half of the appendices so the lettering is unique and matches reading order: A = Glossary, B = References, C = EU AI Act mappings, D = Complete Example.
- Renamed the two affected files to match their corrected letter (`0x92-Appendix-EU-AI-Act-mappings.md` → `0x92-Appendix-C_EU-AI-Act-mappings.md`, `0x93_Appendix-C_Complete_Example.md` → `0x93_Appendix-D_Complete_Example.md`), consistent with how Appendix A and B are already named.
- No other file references these appendices by filename, and the PDF build order is driven by the `0xNN` numeric prefix (unchanged), so this is a content/naming-only fix.