### PR TITLE
fix: correct inputType/outputType image mix-up in MBOM guide

### DIFF
--- a/MBOM/en/0x20-Object-Model.md
+++ b/MBOM/en/0x20-Object-Model.md
@@ -221,7 +221,7 @@ Information about the actual volume instance, if applicable, allocated to worksp
 
 ## inputType relationships
 
-![Object Model - output type](images/Object-Model/inputType.svg)
+![Object Model - input type](images/Object-Model/inputType.svg)
 
 #### `inputType`
 
@@ -249,7 +249,7 @@ An `attachment` Specifies the metadata (e.g., content type, encoding, etc.) and 
 
 ## outputType relationships
 
-![Object Model - input type](images/Object-Model/inputType.svg)
+![Object Model - output type](images/Object-Model/outputType.svg)
 
 #### `outputType`
 


### PR DESCRIPTION
## Summary
- In `MBOM/en/0x20-Object-Model.md`, the "outputType relationships" section pointed its image at `inputType.svg` (with alt text also mismatched), so the diagram was rendered twice under the inputType heading and the actual `outputType.svg` file was never displayed anywhere in the guide.
- Fixed the "inputType relationships" image alt text to match its own section/src, and fixed the "outputType relationships" image to point at `images/Object-Model/outputType.svg` with matching alt text.